### PR TITLE
Removed duplicate preset for subway stations

### DIFF
--- a/data/transit/railway/station.json
+++ b/data/transit/railway/station.json
@@ -7,16 +7,6 @@
   },
   "items": [
     {
-      "note": "Auto create railway/station for all route/subway too - #9320",
-      "templateSource": "transit/route/subway",
-      "templateTags": {
-        "public_transport": "station",
-        "railway": "station",
-        "route": "",
-        "subway": "yes"
-      }
-    },
-    {
       "note": "Auto create railway/station for all route/train - #7576, #4765",
       "templateSource": "transit/route/train",
       "templateTags": {


### PR DESCRIPTION
The other is in the file:
https://github.com/osmlab/name-suggestion-index/blob/main/data/transit/public_transport/station_subway.json
https://nsi.guide/index.html?t=transit&k=public_transport&v=station_subway